### PR TITLE
Add Python tip using enumerate() for loops

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
-# ai-learning
+## Python Tip: Use `enumerate()`
+
+Instead of using a loop with a manual index, use `enumerate()`:

--- a/chatgpt-test.py
+++ b/chatgpt-test.py
@@ -1,8 +1,7 @@
-# chatgpt-test.py
-def some_function():
-    data = ['apple', 'banana', 'cherry']
-    for index, value in enumerate(data):
-        print(index, value)
+def loop_with_enumerate():
+    items = ['apple', 'banana', 'cherry']
+    for index, value in enumerate(items):
+        print(f'Index: {index}, Value: {value}')
 
-if __name__ == "__main__":
-    some_function()
+# Call the function to demonstrate its usage
+loop_with_enumerate()

--- a/chatgpt-test.py
+++ b/chatgpt-test.py
@@ -1,7 +1,6 @@
-def loop_with_enumerate():
-    items = ['apple', 'banana', 'cherry']
-    for index, value in enumerate(items):
-        print(f'Index: {index}, Value: {value}')
+# chatgpt-test.py
 
-# Call the function to demonstrate its usage
-loop_with_enumerate()
+# Example of using enumerate to iterate with index and value
+data = ['apple', 'banana', 'cherry']
+for index, value in enumerate(data):
+    print(f"Index: {index}, Value: {value}")

--- a/chatgpt-test.py
+++ b/chatgpt-test.py
@@ -1,14 +1,8 @@
-# This is a placeholder for AI experiments
-print("Hello AI! This is my first AI script.")
+# chatgpt-test.py
+def some_function():
+    data = ['apple', 'banana', 'cherry']
+    for index, value in enumerate(data):
+        print(index, value)
 
-### Description
-
-# In several Python examples within the project, loops manually track indexes using counters.  
-# Python provides a built-in function `enumerate()` that simplifies this pattern and improves readability.
-
-### Current pattern
-
-items = ['apple', 'banana', 'cherry']
-
-for i, item in enumerate(items):
-    print(i, item)
+if __name__ == "__main__":
+    some_function()


### PR DESCRIPTION
The issue proposes a Python tip to use `enumerate()` for obtaining both the index and the value in loops. This can be demonstrated through a simple example. I will modify `chatgpt-test.py` to include a new function that uses `enumerate()` and update the README with this example.

Fixes #50